### PR TITLE
Bug udma ctrl

### DIFF
--- a/rtl/common/udma_ctrl.sv
+++ b/rtl/common/udma_ctrl.sv
@@ -55,7 +55,7 @@
 module udma_ctrl
   #(
     parameter L2_AWIDTH_NOAL = 15,
-    parameter TRANS_SIZE     = 15 
+    parameter TRANS_SIZE     = 16 
     )
    (
 	input  logic 	                         clk_i,

--- a/rtl/common/udma_ctrl.sv
+++ b/rtl/common/udma_ctrl.sv
@@ -534,18 +534,18 @@ module udma_ctrl
         `REG_TX_CH1_LEN2:
             cfg_data_o[TRANS_SIZE-1:0] = r_filter_tx_len2[1];
         `REG_RX_CH_ADD:
-            cfg_data_o[L2_AWIDTH_NOAL-1:0] = r_filter_rx_start_addr[1];
+            cfg_data_o[L2_AWIDTH_NOAL-1:0] = r_filter_rx_start_addr;
         `REG_RX_CH_CFG:
         begin
-           cfg_data_o[1:0] = r_filter_rx_datasize[1];
-           cfg_data_o[9:8] = r_filter_rx_mode[1]    ;
+           cfg_data_o[1:0] = r_filter_rx_datasize;
+           cfg_data_o[9:8] = r_filter_rx_mode;
         end
         `REG_RX_CH_LEN0:
-            cfg_data_o[15:0] = r_filter_rx_len0[1];
+            cfg_data_o[15:0] = r_filter_rx_len0;
         `REG_RX_CH_LEN1:
-            cfg_data_o[15:0] = r_filter_rx_len1[1];
+            cfg_data_o[15:0] = r_filter_rx_len1;
         `REG_RX_CH_LEN2:
-            cfg_data_o[15:0] = r_filter_rx_len2[1];
+            cfg_data_o[15:0] = r_filter_rx_len2;
         `REG_AU_CFG:
         begin
             cfg_data_o[0]     = r_au_use_signed;


### PR DESCRIPTION
Hi Davide, Francesco and friends in Zurich and Bologna,

we found some copy and paste type errors in udma and will start pushing them to github.com/pulp_plaftform.

This one should be fairly obvious:
2d749b3) r_filter_rx_* signals had an illegal 2-dimensional array select copied over from _tx_ signals
23862df) minor: default parameter size 15 of TRANS_SIZE is incorrect, but is set to 16 in udma_core

Cheers
lut, shao
Fraunhofer IIS