### PR TITLE
Update tech_cells_generic dependency in Bender.yml

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -7,7 +7,7 @@ package:
     - "Pasquale Davide Schiavone <pschiavo@iis.ee.ethz.ch>"
 
 dependencies:
-  tech_cells_generic: { git: "git@github.com:pulp-platform/tech_cells_generic.git", version: 0.1.6 } # requires deprecated pulp_clock_gating_async
+  tech_cells_generic: { git: "git@github.com:pulp-platform/tech_cells_generic.git", version: 0.2.2 } # requires deprecated pulp_clock_gating_async
   common_cells: { git: "git@github.com:pulp-platform/common_cells.git", version: 1.13.1 }
   axi_slice_dc: {git: "git@github.com:pulp-platform/axi_slice_dc.git", version: 1.1.3 } # deprecated, replaced by axi_cdc (in axi repo)
 


### PR DESCRIPTION
tech_cells_generic's Bender.yml file was updated to include the deprecated pulp_clock_gating_async required in this repository, ensuring the module is properly built when using bender.