### PR TITLE
Properly parametrize s_periph_sel.

### DIFF
--- a/rtl/common/udma_apb_if.sv
+++ b/rtl/common/udma_apb_if.sv
@@ -44,14 +44,14 @@ module udma_apb_if
 
 );
 
-    logic [4:0] s_periph_sel;
+    logic [5:0] s_periph_sel;
     logic       s_periph_valid;
 
     assign periph_addr_o  = PADDR[6:2];
     assign periph_rwn_o   = ~PWRITE;
     assign periph_data_o  = PWDATA;
 
-    assign s_periph_sel   = PADDR[11:7];
+    assign s_periph_sel   = PADDR[12:7];
     assign s_periph_valid = PSEL & PENABLE;
 
     assign PSLVERR = 1'b0;

--- a/rtl/common/udma_apb_if.sv
+++ b/rtl/common/udma_apb_if.sv
@@ -44,14 +44,14 @@ module udma_apb_if
 
 );
 
-    logic [5:0] s_periph_sel;
+    logic [$clog2(N_PERIPHS)-1:0] s_periph_sel;
     logic       s_periph_valid;
 
     assign periph_addr_o  = PADDR[6:2];
     assign periph_rwn_o   = ~PWRITE;
     assign periph_data_o  = PWDATA;
 
-    assign s_periph_sel   = PADDR[12:7];
+    assign s_periph_sel   = PADDR[$clog2(N_PERIPHS)+7-1:7];
     assign s_periph_valid = PSEL & PENABLE;
 
     assign PSLVERR = 1'b0;

--- a/rtl/common/udma_ctrl.sv
+++ b/rtl/common/udma_ctrl.sv
@@ -100,9 +100,9 @@ module udma_ctrl
             begin
                 case (s_wr_addr)
                 `REG_CG:
-                    r_cg   <= cfg_data_i[N_PERIPHS-1:0];
+                    r_cg   <= cfg_data_i[31:0];
                 `REG_RST:
-                    r_rst  <= cfg_data_i[N_PERIPHS-1:0];
+                    r_rst  <= cfg_data_i[31:0];
                 `REG_CFG_EVT:
                 begin
                     r_cmp_evt[0] <= cfg_data_i[7:0];
@@ -120,9 +120,9 @@ module udma_ctrl
         cfg_data_o = 32'h0;
         case (s_rd_addr)
         `REG_CG:
-            cfg_data_o[N_PERIPHS-1:0] = r_cg;
+            cfg_data_o[31:0] = r_cg;
         `REG_RST:
-            cfg_data_o[N_PERIPHS-1:0] = r_rst;
+            cfg_data_o[31:0] = r_rst;
         `REG_CFG_EVT:
             cfg_data_o = {r_cmp_evt[3],r_cmp_evt[2],r_cmp_evt[1],r_cmp_evt[0]};
         default:


### PR DESCRIPTION
`s_periph_sel` is fixed to 5 bits. This means that the maximum number of addressable peripherals is actually 32 (counting the udmacore). Parametrizing it, it is possible to have more than 32 peripherals, and to use just the meaningful bits when `N_PERIPHS<32`.